### PR TITLE
增加上传完成回调函数

### DIFF
--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -49,7 +49,10 @@ type Config struct {
 	// PreFinishResponseCallback will be invoked after an upload is completed but before
 	// a response is returned to the client. Error responses from the callback will be passed
 	// back to the client. This can be used to implement post-processing validation.
+	// 这个方法是每次上传完成之前的callback，而不仅仅是整个文件上传完成
 	PreFinishResponseCallback func(hook HookEvent) error
+	// PreCompleteUploadsCallBack 文件上传完成后的处理
+	PreCompleteUploadsCallBack func(hook HookEvent) error
 	// PreGetFileCallback will be invoked before get file
 	PreGetFileCallback func(r *http.Request) error
 	// PreHeadFileCallback will be invoked before head file

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -401,6 +401,12 @@ func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request)
 		if handler.config.NotifyCompleteUploads {
 			handler.CompleteUploads <- newHookEvent(info, r)
 		}
+		if handler.config.PreCompleteUploadsCallBack != nil {
+			if err := handler.config.PreCompleteUploadsCallBack(newHookEvent(info, r)); err != nil {
+				handler.sendError(w, r, err)
+				return
+			}
+		}
 	}
 
 	if containsChunk {
@@ -715,7 +721,11 @@ func (handler *UnroutedHandler) finishUploadIfComplete(ctx context.Context, uplo
 		if handler.config.NotifyCompleteUploads {
 			handler.CompleteUploads <- newHookEvent(info, r)
 		}
-
+		if handler.config.PreCompleteUploadsCallBack != nil {
+			if err := handler.config.PreCompleteUploadsCallBack(newHookEvent(info, r)); err != nil {
+				return err
+			}
+		}
 		handler.Metrics.incUploadsFinished()
 
 		if handler.config.PreFinishResponseCallback != nil {


### PR DESCRIPTION
与监听uploadComplete chan不同的是，监听chan是异步逻辑，处理chan时tus服务器已经返回客户端上传成功。而新增的callback是同步逻辑，执行完callback才会返回客户端上传成功，callback执行失败会返回客户端失败