### PR TITLE
Let downloads opt into browser-inline web assets

### DIFF
--- a/pkg/handler/get_test.go
+++ b/pkg/handler/get_test.go
@@ -783,4 +783,90 @@ func TestGet(t *testing.T) {
 			ResBody: "x",
 		}).Run(handler, t)
 	})
+
+	SubTest(t, "FiletypeShorthandWebAssets", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
+		tests := []struct {
+			filetype    string
+			contentType string
+		}{
+			{filetype: "html", contentType: "text/html"},
+			{filetype: "css", contentType: "text/css"},
+			{filetype: "js", contentType: "application/javascript"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.filetype, func(t *testing.T) {
+				reader := &closingStringReader{
+					Reader: strings.NewReader("asset"),
+				}
+
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				upload := NewMockFullUpload(ctrl)
+
+				gomock.InOrder(
+					store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
+					upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+						Offset: 5,
+						MetaData: map[string]string{
+							"filetype": tt.filetype,
+						},
+					}, nil),
+					upload.EXPECT().GetReader(context.Background()).Return(reader, nil),
+				)
+
+				handler, _ := NewHandler(Config{
+					StoreComposer: composer,
+				})
+
+				(&httpTest{
+					Method: "GET",
+					URL:    "yes",
+					ResHeader: map[string]string{
+						"Content-Type":        tt.contentType,
+						"Content-Disposition": "attachment",
+					},
+					Code:    http.StatusOK,
+					ResBody: "asset",
+				}).Run(handler, t)
+			})
+		}
+	})
+
+	SubTest(t, "InlineQueryForcesAttachmentFileTypeInline", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
+		reader := &closingStringReader{
+			Reader: strings.NewReader("<html></html>"),
+		}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		upload := NewMockFullUpload(ctrl)
+
+		gomock.InOrder(
+			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+				Offset: 13,
+				MetaData: map[string]string{
+					"filetype": "html",
+					"filename": "index.html",
+				},
+			}, nil),
+			upload.EXPECT().GetReader(context.Background()).Return(reader, nil),
+		)
+
+		handler, _ := NewHandler(Config{
+			StoreComposer: composer,
+		})
+
+		(&httpTest{
+			Method: "GET",
+			URL:    "yes?inline=true",
+			ResHeader: map[string]string{
+				"Content-Type":        "text/html",
+				"Content-Disposition": `inline;filename="index.html"`,
+			},
+			Code:    http.StatusOK,
+			ResBody: "<html></html>",
+		}).Run(handler, t)
+	})
 }

--- a/pkg/handler/get_test.go
+++ b/pkg/handler/get_test.go
@@ -869,4 +869,62 @@ func TestGet(t *testing.T) {
 			ResBody: "<html></html>",
 		}).Run(handler, t)
 	})
+
+	SubTest(t, "ParameterizedMimeTypeReturnsBaseContentType", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
+		tests := []struct {
+			name               string
+			url                string
+			contentDisposition string
+		}{
+			{
+				name:               "default attachment",
+				url:                "yes",
+				contentDisposition: `attachment;filename="style.css"`,
+			},
+			{
+				name:               "inline query",
+				url:                "yes?inline=true",
+				contentDisposition: `inline;filename="style.css"`,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				reader := &closingStringReader{
+					Reader: strings.NewReader("body"),
+				}
+
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				upload := NewMockFullUpload(ctrl)
+
+				gomock.InOrder(
+					store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
+					upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+						Offset: 4,
+						MetaData: map[string]string{
+							"filetype": "text/css; charset=utf-8",
+							"filename": "style.css",
+						},
+					}, nil),
+					upload.EXPECT().GetReader(context.Background()).Return(reader, nil),
+				)
+
+				handler, _ := NewHandler(Config{
+					StoreComposer: composer,
+				})
+
+				(&httpTest{
+					Method: "GET",
+					URL:    tt.url,
+					ResHeader: map[string]string{
+						"Content-Type":        "text/css",
+						"Content-Disposition": tt.contentDisposition,
+					},
+					Code:    http.StatusOK,
+					ResBody: "body",
+				}).Run(handler, t)
+			})
+		}
+	})
 }

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -877,6 +877,9 @@ func (handler *UnroutedHandler) GetFile(w http.ResponseWriter, r *http.Request) 
 	}
 
 	contentType, contentDisposition := filterContentType(info)
+	if r.URL.Query().Get("inline") == "true" {
+		contentDisposition = forceInlineContentDisposition(contentDisposition)
+	}
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Disposition", contentDisposition)
 	w.Header().Set("Accept-Ranges", "bytes")
@@ -958,6 +961,11 @@ func (handler *UnroutedHandler) GetFile(w http.ResponseWriter, r *http.Request) 
 var filetypeShorthandToMIME = map[string]string{
 	"txt":   "text/plain",
 	"plain": "text/plain",
+	"html":  "text/html",
+	"htm":   "text/html",
+	"css":   "text/css",
+	"js":    "application/javascript",
+	"mjs":   "application/javascript",
 
 	"png":  "image/png",
 	"jpeg": "image/jpeg",
@@ -966,12 +974,12 @@ var filetypeShorthandToMIME = map[string]string{
 	"bmp":  "image/bmp",
 	"webp": "image/webp",
 
-	"wave":    "audio/wave",
-	"wav":     "audio/wav",
-	"x-wav":   "audio/x-wav",
+	"wave":     "audio/wave",
+	"wav":      "audio/wav",
+	"x-wav":    "audio/x-wav",
 	"x-pn-wav": "audio/x-pn-wav",
-	"webm":    "video/webm",
-	"ogg":     "application/ogg",
+	"webm":     "video/webm",
+	"ogg":      "application/ogg",
 
 	"mp4": "video/mp4",
 	"avi": "video/avi",
@@ -1060,6 +1068,13 @@ func filterContentType(info FileInfo) (contentType string, contentDisposition st
 	}
 
 	return contentType, contentDisposition
+}
+
+func forceInlineContentDisposition(contentDisposition string) string {
+	if separator := strings.Index(contentDisposition, ";"); separator >= 0 {
+		return "inline" + contentDisposition[separator:]
+	}
+	return "inline"
 }
 
 // DelFile terminates an upload permanently.

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"math"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -995,8 +996,8 @@ func normalizeMetadataFiletype(raw string) string {
 	if trimmed == "" {
 		return trimmed
 	}
-	if reMimeType.MatchString(trimmed) {
-		return trimmed
+	if mediaType, _, err := mime.ParseMediaType(trimmed); err == nil && reMimeType.MatchString(mediaType) {
+		return mediaType
 	}
 	if canonical, ok := filetypeShorthandToMIME[strings.ToLower(trimmed)]; ok {
 		return canonical


### PR DESCRIPTION
Downloaded uploads can now advertise web asset MIME types from shorthand metadata while callers may explicitly request inline content disposition with an inline=true query parameter. The inline override keeps any existing filename parameter intact so clients do not lose download naming metadata.

Constraint: Preserve default attachment behavior for non-whitelisted MIME types unless the request explicitly asks for inline=true

Rejected: Add HTML CSS JS to the inline whitelist | would change default browser execution behavior for existing downloads

Confidence: medium

Scope-risk: narrow

Directive: Treat inline=true as a caller-owned trust decision; do not make web assets inline by default without reviewing browser execution risk

Tested: gofmt -w pkg/handler/get_test.go pkg/handler/unrouted_handler.go

Tested: git diff --check -- pkg/handler/get_test.go pkg/handler/unrouted_handler.go

Not-tested: go test ./pkg/handler and go test ./... are blocked by existing pkg/handler/post_test.go CreatedUploads compile error